### PR TITLE
fix: harden claude-code package updates

### DIFF
--- a/docs/adr/0003-fail-loud-automated-package-updates.md
+++ b/docs/adr/0003-fail-loud-automated-package-updates.md
@@ -29,6 +29,8 @@ Updater scripts must:
 
 - compute complete SRI hashes before patching package files
 - exit non-zero if a required hash is empty, malformed, or unavailable
+- validate upstream package layout assumptions before patching package files
+- build the changed derivation before opening or refreshing an update PR when the package has generated dependency state or native wrapper packaging
 - avoid committing or refreshing a PR when validation fails
 - use `lib.fakeHash` only as an explicit package-maintainer choice for an optional missing upstream asset, not as a fallback for failed required hashes
 
@@ -38,6 +40,7 @@ CI must:
 - test every Go tool module present under `tools/`
 - build the changed `x86_64-linux` package when the runner can evaluate it
 - validate Darwin-only package metadata when the Linux runner cannot build the package
+- compare pull request heads against the target branch, and use a conservative promotion baseline when the runner does not expose a target branch variable
 - avoid stale references to deleted or retired packages
 
 The scheduled updater may retry on the next scheduled run from a clean checkout. It must not silently carry invalid generated state forward.
@@ -52,6 +55,7 @@ The scheduled updater may retry on the next scheduled run from a clean checkout.
 ## Consequences
 
 - Bad generated hashes fail earlier and more clearly.
+- Upstream package layout changes fail before a generated update PR is refreshed.
 - Update PR checks are more relevant because they include the changed package.
 - Darwin-only packages still need occasional real Darwin builds for full confidence.
 - Adding a new updater script requires maintaining the same fail-loud hash validation behavior.

--- a/pkgs/claude-code/default.nix
+++ b/pkgs/claude-code/default.nix
@@ -22,9 +22,6 @@ buildNpmPackage (finalAttrs: {
 
   postPatch = ''
     cp ${./package-lock.json} package-lock.json
-
-    substituteInPlace cli.js \
-          --replace-fail '#!/bin/sh' '#!/usr/bin/env sh'
   '';
 
   dontNpmBuild = true;

--- a/scripts/ci/build-changed-packages.sh
+++ b/scripts/ci/build-changed-packages.sh
@@ -12,12 +12,21 @@ for attr in agent-sync-check forge-mirror nix-deploy zfs-auto-unlock devlog wcap
   echo "::endgroup::"
 done
 
-if [ -n "${GITHUB_BASE_REF:-}" ]; then
-  git fetch origin "${GITHUB_BASE_REF}"
-  base="origin/${GITHUB_BASE_REF}"
+base_ref="${GITHUB_BASE_REF:-${GITEA_BASE_REF:-${FORGEJO_BASE_REF:-}}}"
+ref_name="${GITHUB_REF_NAME:-${GITEA_REF_NAME:-${FORGEJO_REF_NAME:-}}}"
+
+if [ -n "$base_ref" ]; then
+  git fetch origin "$base_ref"
+  base="origin/${base_ref}"
+elif [ "$ref_name" = "main" ]; then
+  base="$(git rev-parse HEAD^)"
+elif git rev-parse --verify origin/main >/dev/null 2>&1; then
+  base="origin/main"
 else
   base="$(git rev-parse HEAD^)"
 fi
+
+echo "Detecting changed packages against ${base}"
 
 changed_attrs="$(
   git diff --name-only "${base}"...HEAD \

--- a/scripts/update-packages/update-claude-code.sh
+++ b/scripts/update-packages/update-claude-code.sh
@@ -36,6 +36,27 @@ trap 'rm -rf "$tmp"' EXIT
 
 curl -fsSL -o "$tmp/package.tgz" "$tgz_url"
 tar xzf "$tmp/package.tgz" -C "$tmp"
+
+PACKAGE_JSON="$tmp/package/package.json" python3 - <<'PYEOF'
+import json
+import os
+from pathlib import Path
+
+package_json = Path(os.environ["PACKAGE_JSON"])
+package_dir = package_json.parent
+metadata = json.loads(package_json.read_text())
+bin_entry = metadata.get("bin", {}).get("claude")
+
+if not bin_entry:
+    raise SystemExit("claude-code package.json does not define bin.claude")
+
+bin_path = package_dir / bin_entry
+if not bin_path.is_file():
+    raise SystemExit(f"claude-code bin.claude points to missing file: {bin_entry}")
+
+print(f"Validated claude-code package layout: bin.claude -> {bin_entry}")
+PYEOF
+
 cd "$tmp/package"
 npm install --package-lock-only --ignore-scripts 2>/dev/null
 cp package-lock.json "$OLDPWD/$PKG_DIR/package-lock.json"
@@ -77,6 +98,10 @@ content = re.sub(r'(npmDepsHash = )"[^"]+"', rf'\g<1>"{npm_deps_hash}"', content
 open(path, 'w').write(content)
 print(f"Patched {path} → {version}")
 PYEOF
+
+echo "Validating claude-code derivation build..."
+rm -rf /homeless-shelter
+nix build .#claude-code --no-link
 
 echo "updated=true"                >> "$GITHUB_OUTPUT"
 echo "version=$latest_version"     >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
Closes #16.

## Summary

- remove the stale `cli.js` patch from the `claude-code` derivation now that upstream ships `bin/claude.exe`
- validate the upstream `bin.claude` layout in the `claude-code` updater before patching generated state
- make the `claude-code` updater build `.#claude-code` before it can open or refresh an update PR
- improve changed-package CI base detection for Forgejo/Gitea/GitHub PR env vars and document the guardrail in ADR-0003

## Validation

- `bash -n scripts/update-packages/update-claude-code.sh scripts/ci/build-changed-packages.sh`
- `nix build .#claude-code --no-link`
- `GITHUB_BASE_REF=main scripts/ci/build-changed-packages.sh`